### PR TITLE
update build files for sbt-idea-plugin 2.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,36 +3,11 @@ ThisBuild / ideaEdition := IdeaEdition.Community
 ThisBuild / ideaBuild := "183.4284.93"
 
 lazy val easycursor = (project in file("."))
-  .enablePlugins(SbtIdeaPlugin)
   .settings(
     organization := "net.uzimith",
     scalaVersion := "2.12.7",
-    assembly / assemblyExcludedJars := ideaFullJars.value,
-    Global / onLoad ~= { _.andThen("updateIdea" :: _) },
+    packageMethod := PackagingMethod.Standalone(),
+    packageLibraryMappings := Seq.empty
   )
 
-lazy val ideaRunner = (project in file("target/tools"))
-  .settings(
-    scalaVersion := "2.12.7",
-    autoScalaLibrary := false,
-    unmanagedJars in Compile := ideaMainJars.value,
-    unmanagedJars in Compile += file(System.getProperty("java.home")).getParentFile / "lib" / "tools.jar",
-    Compile / compile := ((Compile / compile) dependsOn (easycursor / assembly)).value,
-    Compile / run / mainClass := Some("com.intellij.idea.Main"),
-    run / javaOptions := Seq(
-      "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005",
-      s"-Didea.home=${ideaBaseDirectory.value.getPath}",
-      s"-Didea.system.path=${ideaTestSystemDir.value}",
-      s"-Didea.config.path=${ideaTestConfigDir.value}",
-      s"-Dplugin.path=${(easycursor / assembly / assemblyOutputPath).value}",
-    ),
-    run / fork := true
-  )
-
-easycursor / packagePluginZip := {
-  val pluginJar = (easycursor / assembly).value
-  val sources = Seq(pluginJar -> s"${(easycursor / ideaPluginName).value}/lib/${pluginJar.getName}")
-  val out = (easycursor / target).value / s"${(easycursor / ideaPluginName).value}.zip"
-  IO.zip(sources, out)
-  out
-}
+lazy val ideaRunner = createRunnerProject(easycursor, "ideaRunner")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
 addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "2.2.8")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.8")


### PR DESCRIPTION
This brings the build file in line with the features of sbt-idea-plugin version 2.x
Note that using sbt-shell is advised when developing a plugin for IDEA.

Namely:
- the plugin is enabled automatically
- artifact packaging(including assembly) is handled by the plugin
- `updateIdea` task is run run on startup by default
- there is a helper function to create a runner project

Also it is advised to run your plugin from IDEA(after creating a run configuration with `ideaRunner/createIDEARunConfiguration` task) since sbt cannot correctly terminate the process.

When running/debugging the produced configuration from IDEA, the sbt plugin will automatically build a debuggable artifact by calling `products` task which is aliased to `packagePluginDynamic`.

To package a redistributable artifact(a zip archive) you can use `packagePlugin` task after doing a clean.

By default, artifacts are placed under `target/plugin/easycursor` in your project folder.